### PR TITLE
fix: custom port not working

### DIFF
--- a/packages/shuvi/src/cli/cmds/dev.ts
+++ b/packages/shuvi/src/cli/cmds/dev.ts
@@ -16,7 +16,7 @@ export default async function main(argv: string[]) {
     .parse(argv, { from: 'user' });
 
   const cwd = getProjectDir(program);
-  const port = program.port || 3000;
+  const port = Number(program.port) || 3000;
   const host = program.host || 'localhost';
 
   const shuviApp = shuvi({

--- a/packages/shuvi/src/cli/cmds/serve.ts
+++ b/packages/shuvi/src/cli/cmds/serve.ts
@@ -16,7 +16,7 @@ export default async function main(argv: string[]) {
     .parse(argv, { from: 'user' });
 
   const cwd = getProjectDir(program);
-  const port = program.port || 3000;
+  const port = Number(program.port) || 3000;
   const host = program.host || 'localhost';
 
   const shuviApp = shuvi({


### PR DESCRIPTION
-  This line check for deep equality and program.port is a string. So --port=3000, we get port="3000" and "3000" !== 3000 
https://github.com/shuvijs/shuvi/blob/master/packages/shuvi/src/server/server.ts#L82