### PR TITLE
[RFC] feat(config): add support for custom userModuleName

### DIFF
--- a/packages/shuvi/src/api/initCoreResource.ts
+++ b/packages/shuvi/src/api/initCoreResource.ts
@@ -1,47 +1,53 @@
-import path from "path";
-import fse from "fs-extra";
-import { parseTemplateFile } from "../lib/viewTemplate";
+import path from 'path';
+import fse from 'fs-extra';
+import { parseTemplateFile } from '../lib/viewTemplate';
 import {
   BUILD_CLIENT_DIR,
   BUILD_SERVER_DIR,
   BUILD_MANIFEST_PATH,
   BUILD_SERVER_FILE_SERVER
-} from "../constants";
-import { Api } from "./api";
+} from '../constants';
+import { Api } from './api';
 
 function resolveServerDist(api: Api, name: string) {
   const manifest = api.resources.serverManifest;
-  return path.join(api.paths.buildDir, BUILD_SERVER_DIR, manifest.bundles[name]);
+  return path.join(
+    api.paths.buildDir,
+    BUILD_SERVER_DIR,
+    manifest.bundles[name]
+  );
 }
 
 function resolveDocument(api: Api) {
-  const customDoc = api.resolveUserFile("document.ejs");
+  const customDoc = api.resolveUserFile(
+    `${api.config.userModuleName!.document}.ejs`
+  );
   if (fse.existsSync(customDoc)) {
     return customDoc;
   }
 
-  return require.resolve("@shuvi/runtime-core/template/document.ejs");
+  return require.resolve('@shuvi/runtime-core/template/document.ejs');
 }
 
 export function initCoreResource(api: Api) {
-  api.addResoure("clientManifest", () =>
+  api.addResoure('clientManifest', () =>
     require(path.join(
       api.paths.buildDir,
       BUILD_CLIENT_DIR,
       BUILD_MANIFEST_PATH
     ))
   );
-  api.addResoure("serverManifest", () =>
+  api.addResoure('serverManifest', () =>
     require(path.join(
       api.paths.buildDir,
       BUILD_SERVER_DIR,
       BUILD_MANIFEST_PATH
     ))
   );
-  api.addResoure("server", () =>
+  api.addResoure('server', () =>
     require(resolveServerDist(api, BUILD_SERVER_FILE_SERVER))
   );
-  api.addResoure("documentTemplate", () =>
+  api.addResoure('documentTemplate', () =>
     parseTemplateFile(resolveDocument(api))
   );
 }

--- a/packages/shuvi/src/api/setupApp.ts
+++ b/packages/shuvi/src/api/setupApp.ts
@@ -56,19 +56,28 @@ export async function setupApp(api: Api) {
 
   api.setViewModule(runtime.getViewModulePath());
   api.setAppModule([
-    ...withExts(api.resolveUserFile('app'), moduleFileExtensions),
+    ...withExts(
+      api.resolveUserFile(config.userModuleName!.app),
+      moduleFileExtensions
+    ),
     runtime.getAppModulePath()
   ]);
 
   api.setPluginModule([
-    ...withExts(api.resolveUserFile('plugin'), moduleFileExtensions),
+    ...withExts(
+      api.resolveUserFile(config.userModuleName!.plugin),
+      moduleFileExtensions
+    ),
     require.resolve('@shuvi/utils/lib/noopFn')
   ]);
 
   api.addAppFile(
     File.moduleProxy('404.js', {
       source: [
-        ...withExts(api.resolveUserFile('404'), moduleFileExtensions),
+        ...withExts(
+          api.resolveUserFile(config.userModuleName!['404']),
+          moduleFileExtensions
+        ),
         runtime.get404ModulePath()
       ],
       defaultExport: true
@@ -79,7 +88,10 @@ export async function setupApp(api: Api) {
   api.addAppFile(
     File.moduleProxy('server.js', {
       source: [
-        ...withExts(api.resolveUserFile('server'), moduleFileExtensions),
+        ...withExts(
+          api.resolveUserFile(config.userModuleName!.server),
+          moduleFileExtensions
+        ),
         require.resolve('@shuvi/utils/lib/noop')
       ]
     }),
@@ -88,7 +100,10 @@ export async function setupApp(api: Api) {
   api.addAppFile(
     File.moduleProxy('document.js', {
       source: [
-        ...withExts(api.resolveUserFile('document'), moduleFileExtensions),
+        ...withExts(
+          api.resolveUserFile(config.userModuleName!.document),
+          moduleFileExtensions
+        ),
         require.resolve('@shuvi/utils/lib/noop')
       ]
     }),

--- a/packages/shuvi/src/config/index.ts
+++ b/packages/shuvi/src/config/index.ts
@@ -21,6 +21,13 @@ export const defaultConfig: IApiConfig = {
   publicPath: PUBLIC_PATH,
   router: {
     history: 'auto'
+  },
+  userModuleName: {
+    app: 'app',
+    plugin: 'plugin',
+    404: '404',
+    server: 'server',
+    document: 'document'
   }
 };
 

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -91,6 +91,14 @@ export interface IApiConfig {
   plugins?: IPluginConfig[];
   presets?: IPresetConfig[];
   analyze?: boolean;
+  userModuleName?: {
+    // Note: filename without extension
+    app: string;
+    plugin: string;
+    404: string;
+    server: string;
+    document: string;
+  };
 }
 
 // api for plugins

--- a/test/e2e/custom-builtin.test.ts
+++ b/test/e2e/custom-builtin.test.ts
@@ -150,3 +150,29 @@ describe('Custom Server.js', () => {
     expect(await page.$text('div')).toMatch(/404 Page/);
   });
 });
+
+describe('Custom userModuleName', () => {
+  beforeAll(async () => {
+    ctx = await launchFixture('custom-userModuleName');
+  });
+  afterAll(async () => {
+    await ctx.close();
+  });
+  afterEach(async () => {
+    await page.close();
+    // force require to load file to make sure compiled file get load correctlly
+    jest.resetModules();
+  });
+
+  test('should work', async () => {
+    page = await ctx.browser.page(ctx.url('/'));
+
+    // Note: custom app
+    await page.waitForSelector('#app');
+    expect(await page.$text('#app')).toBe('custom-userModuleName');
+
+    // Note: custom document
+    expect(await page.$attr('meta[name="test"]', 'content')).toBe('1');
+    expect(await page.$attr('body', 'test')).toBe('_document');
+  });
+});

--- a/test/fixtures/custom-userModuleName/shuvi.config.js
+++ b/test/fixtures/custom-userModuleName/shuvi.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  ssr: true,
+  userModuleName: {
+    app: 'app.web',
+    document: '_document'
+  }
+};

--- a/test/fixtures/custom-userModuleName/src/_document.ejs
+++ b/test/fixtures/custom-userModuleName/src/_document.ejs
@@ -1,0 +1,10 @@
+<!doctype html>
+<html<%- htmlAttrs %>>
+<head>
+  <%- head %>
+</head>
+<body test="<%= test %>">
+  <%- main %>
+  <%- script %>
+</body>
+</html>

--- a/test/fixtures/custom-userModuleName/src/_document.js
+++ b/test/fixtures/custom-userModuleName/src/_document.js
@@ -1,0 +1,15 @@
+export function getTemplateData() {
+  return { test: '_document' };
+}
+
+export function onDocumentProps(documentProps) {
+  documentProps.headTags.push({
+    tagName: 'meta',
+    attrs: {
+      name: 'test',
+      content: '1'
+    }
+  });
+
+  return documentProps;
+}

--- a/test/fixtures/custom-userModuleName/src/app.web.js
+++ b/test/fixtures/custom-userModuleName/src/app.web.js
@@ -1,0 +1,10 @@
+import { App } from '@shuvi/app';
+
+const MyApp = props => (
+  <div>
+    <div id="app">custom-userModuleName</div>
+    <App />
+  </div>
+);
+
+export default MyApp;

--- a/test/fixtures/custom-userModuleName/src/pages/index.js
+++ b/test/fixtures/custom-userModuleName/src/pages/index.js
@@ -1,0 +1,8 @@
+const Index = props => <div>{props.content}</div>;
+
+Index.getInitialProps = async () => {
+  return {
+    content: 'Index Page'
+  };
+};
+export default Index;


### PR DESCRIPTION
## Request for comments

If consumers are able to change the name of the module (i.e., `userModuleName`) defined by shuvi (e.g., `app`, `document`, `plugin`, etc.), it is possible to customize the filename in plugin:

```ts
// shuvi-plugin-electron

class Plugin {
  modifyConfig(config: ElectronShuviConfig) {
    if (process.env.ELECTRON === 'true') {
      config.userModuleName.app = 'app.electron'
    } else {
      config.userModuleName.app = 'app.web'
    }

    return config
  }
  ...
}
```

cc @liximomo 