### PR TITLE
[RFC] feat: support options for serverMiddleware

### DIFF
--- a/packages/core/src/app/__tests__/app.test.ts
+++ b/packages/core/src/app/__tests__/app.test.ts
@@ -49,6 +49,11 @@ describe('app', () => {
       path: '/',
       handler: 'path/api/set-header'
     });
+    app.addServerMiddleware('cache', {
+      path: '*',
+      handler: 'api/cache',
+      options: [{ maxAge: 2 * 60 * 1000 }]
+    });
 
     await app.build({
       dir: BUILD_DIR
@@ -64,7 +69,13 @@ describe('app', () => {
       ['core/routes.js', 'routes content'],
       [
         'core/serverMiddleware.js',
-        'import path_api_setHeader from "path/api/set-header";\n\nexport default [\n  { path: "/", handler: path_api_setHeader },\n];'
+        `import path_api_setHeader from "path/api/set-header";
+import api_cache from "api/cache";
+
+export default [
+  { path: "/", handler: path_api_setHeader },
+  { path: "*", handler: api_cache({"maxAge":120000}) },
+];`
       ]
     ]);
   });

--- a/packages/core/src/app/app.tsx
+++ b/packages/core/src/app/app.tsx
@@ -39,7 +39,7 @@ export class App {
 
   addServerMiddleware(
     key: string,
-    value: { path: string; handler: string; }
+    value: { path: string; handler: string; options?: any[] }
   ): void {
     this._store.addServerMiddleware(key, value);
   }

--- a/packages/core/src/app/components/ServerMiddlewareFile.tsx
+++ b/packages/core/src/app/components/ServerMiddlewareFile.tsx
@@ -17,6 +17,10 @@ function makeVariableName(str: string) {
     .replace(/^(.)/, s => s.toLowerCase());
 }
 
+function toParamterString(options: any[]) {
+  return options.map(e => JSON.stringify(e)).join(', ');
+}
+
 function ServerMiddleware() {
   const serverMiddleware = useSelector(state => state.serverMiddleware);
 
@@ -25,10 +29,12 @@ function ServerMiddleware() {
 
   const uniqueImports = new Map<string, string>();
 
-  serverMiddleware.forEach(({ path, handler }) => {
+  serverMiddleware.forEach(({ path, handler, options }) => {
     const importName = makeVariableName(handler);
     uniqueImports.set(handler, importName);
-    exportContent += `\n  { path: "${path}", handler: ${importName} },`;
+    exportContent += `\n  { path: "${path}", handler: ${
+      options ? `${importName}(${toParamterString(options)})` : importName
+    } },`;
   });
 
   uniqueImports.forEach((v, k) => {

--- a/packages/core/src/app/models/ModelApp.ts
+++ b/packages/core/src/app/models/ModelApp.ts
@@ -68,7 +68,7 @@ export class ModelApp {
   @observable runtimePlugins = new Map<string, string>();
   @observable serverMiddleware = new Map<
     string,
-    { path: string; handler: string }
+    { path: string; handler: string; options?: any[] }
   >();
 
   @computed
@@ -121,7 +121,10 @@ export class ModelApp {
   }
 
   @action
-  addServerMiddleware(key: string, value: { path: string; handler: string }) {
+  addServerMiddleware(
+    key: string,
+    value: { path: string; handler: string; options?: any[] }
+  ) {
     if (this.serverMiddleware.get(key)) {
       throw new Error(`duplicated middleware "${key}"`);
     }

--- a/packages/shuvi/src/api/api.ts
+++ b/packages/shuvi/src/api/api.ts
@@ -249,7 +249,7 @@ class Api extends Hookable implements IApi {
 
   addServerMiddleware(
     key: string,
-    value: { path: string; handler: string }
+    value: { path: string; handler: string; options?: any[] }
   ): void {
     this._app.addServerMiddleware(key, value);
   }
@@ -388,13 +388,15 @@ class Api extends Hookable implements IApi {
 
   private async _initServerMiddleware() {
     (this._config.serverMiddleware || []).forEach(serverMiddleware => {
-      const { path, handler } = normalizeServerMiddleware(serverMiddleware);
+      const { path, handler, options } = normalizeServerMiddleware(
+        serverMiddleware
+      );
       const resolved = resolveHandler(handler, {
         rootDir: this._paths.rootDir,
         srcDir: this._paths.srcDir
       });
-      const key = `${path} -> ${handler}`;
-      this._app.addServerMiddleware(key, { path, handler: resolved });
+      const key = `${path} -> ${handler}, options: ${JSON.stringify(options)}`;
+      this._app.addServerMiddleware(key, { path, handler: resolved, options });
     });
   }
 }

--- a/packages/shuvi/src/api/serverMiddleware.ts
+++ b/packages/shuvi/src/api/serverMiddleware.ts
@@ -49,13 +49,15 @@ export function resolveHandler(handler: string, options: Options) {
 
 export function normalizeServerMiddleware(
   middleware: IServerMiddlewareConfig
-): { path: string; handler: string } {
+): { path: string; handler: string; options?: any[] } {
   let path: string;
   let handler: string;
+  let options: any[] | undefined;
 
   if (typeof middleware === 'object') {
     path = middleware.path;
     handler = middleware.handler;
+    options = middleware.options;
   } else if (typeof middleware === 'string') {
     path = '*'; // Note: match all routes
     handler = middleware;
@@ -63,5 +65,5 @@ export function normalizeServerMiddleware(
     throw new Error(`Middleware must be one of type [string, object]`);
   }
 
-  return { path, handler };
+  return { path, handler, options };
 }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -75,7 +75,7 @@ export type IPresetConfig =
 
 export type IServerMiddlewareConfig =
   | string /* handler */
-  | { path: string; handler: string };
+  | { path: string; handler: string; options?: any[] };
 
 export type IRuntimeConfig = Record<string, string>;
 

--- a/test/e2e/serverMiddleware.dev.test.ts
+++ b/test/e2e/serverMiddleware.dev.test.ts
@@ -26,6 +26,7 @@ describe('serverMiddleware development', () => {
     expect(res.headers).toHaveProperty('set-cookie', [
       'shuvi-middleware-custom-cookie=foo; path=/; httponly'
     ]);
+    expect(res.headers).not.toHaveProperty('cache-control');
 
     res = await got.get(ctx.url('/health-check2'));
     expect(res.body).toBe('200 OK');
@@ -33,6 +34,7 @@ describe('serverMiddleware development', () => {
     expect(res.headers).toHaveProperty('set-cookie', [
       'shuvi-middleware-custom-cookie=foo; path=/; httponly'
     ]);
+    expect(res.headers).toHaveProperty('cache-control', 'max-age=120, must-revalidate');
 
     res = await got.get(ctx.url('/health-check3'));
     expect(res.body).toBe('200 OK');
@@ -40,6 +42,7 @@ describe('serverMiddleware development', () => {
     expect(res.headers).toHaveProperty('set-cookie', [
       'shuvi-middleware-custom-cookie=foo; path=/; httponly'
     ]);
+    expect(res.headers).toHaveProperty('cache-control', 'no-cache, no-store, must-revalidate');
 
     res = await got.get(ctx.url('/home'));
     expect(res.headers).toHaveProperty('shuvi-middleware-custom-header', 'bar');

--- a/test/e2e/serverMiddleware.prod.test.ts
+++ b/test/e2e/serverMiddleware.prod.test.ts
@@ -29,6 +29,7 @@ describe('serverMiddleware production', () => {
     expect(res.headers).toHaveProperty('set-cookie', [
       'shuvi-middleware-custom-cookie=foo; path=/; httponly'
     ]);
+    expect(res.headers).not.toHaveProperty('cache-control');
 
     res = await got.get(ctx.url('/health-check2'));
     expect(res.body).toBe('200 OK');
@@ -36,6 +37,7 @@ describe('serverMiddleware production', () => {
     expect(res.headers).toHaveProperty('set-cookie', [
       'shuvi-middleware-custom-cookie=foo; path=/; httponly'
     ]);
+    expect(res.headers).toHaveProperty('cache-control', 'max-age=120, must-revalidate');
 
     res = await got.get(ctx.url('/health-check3'));
     expect(res.body).toBe('200 OK');
@@ -43,6 +45,7 @@ describe('serverMiddleware production', () => {
     expect(res.headers).toHaveProperty('set-cookie', [
       'shuvi-middleware-custom-cookie=foo; path=/; httponly'
     ]);
+    expect(res.headers).toHaveProperty('cache-control', 'no-cache, no-store, must-revalidate');
 
     res = await got.get(ctx.url('/home'));
     expect(res.headers).toHaveProperty('shuvi-middleware-custom-header', 'bar');

--- a/test/fixtures/serverMiddleware/shuvi.config.js
+++ b/test/fixtures/serverMiddleware/shuvi.config.js
@@ -5,6 +5,12 @@ module.exports = {
   serverMiddleware: [
     'koa-lowercase',
     './api/set-header.js', // Note: will be resolved from `src` directory and extension is optional.
+    {
+      path: '/health-check2',
+      handler: 'api/cache', // Note: it's a handler factory with options
+      options: [{ maxAge: 2 * 60 * 1000 }]
+    }, 
+    { path: '/health-check3', handler: 'api/cache', options: [false] },
     { path: '/health-check*', handler: 'api/set-cookie' },
     { path: '/health-check', handler: 'api/health-check' },
     { path: '/health-check2', handler: 'api/health-check' }, // Note: share handler with other path
@@ -16,6 +22,6 @@ module.exports = {
     { path: '/users/:id', handler: 'api/user' },
     { path: '/profile/:id/setting*', handler: 'api/setting' },
 
-    { path: '/home', handler: 'api/modify-html' },
+    { path: '/home', handler: 'api/modify-html' }
   ]
 };

--- a/test/fixtures/serverMiddleware/src/api/cache.js
+++ b/test/fixtures/serverMiddleware/src/api/cache.js
@@ -1,0 +1,16 @@
+const HEADER_KEY_CACHE_CONTROL = 'cache-control';
+const NO_CACHE = 'no-cache, no-store, must-revalidate'
+const WITH_CACHE = age => `max-age=${age}, must-revalidate`;
+const ZERO = 0;
+
+export default cache => {
+  return async (ctx, next) => {
+    ctx.set(
+      HEADER_KEY_CACHE_CONTROL,
+      cache === false
+        ? NO_CACHE
+        : WITH_CACHE(parseInt((cache.maxAge || ZERO) / 1000, 10))
+    );
+    await next();
+  };
+};


### PR DESCRIPTION
> This PR implements Approach2

## Options for serverMiddleware

There are two approaches to support additional options for serverMiddleware, i.e., a **middleware factory**:

```js
// Say you have the following middleware factory:

// src/api/cache.js
export default (cache) => {
  return async (ctx, next) => {
    ctx.set("cache-control" /*...*/);
  };
};
```

### Approach1: Inline function

> Nuxt.js use approach1.

```js
// shuvi.config.js
import cache from "./api/cache";

serverMiddleware: [{ path: "*", handler: cache({ maxAge: 2 * 60 * 1000 }) }];
```

##### pros:

- Typescript support (Is it okay to use `shuvi.config.ts`?)
- More flexible if there are unexpected type signatures. In the cases listed below may not be supported by approach2:

```js
// case1: two wraps of factory
(options1?: any[]) => (options2?: any[]) => Middleware

// case2: not a common koa middleware
(ctx, next, options?: any[]) => void;
```

### Approach2: Config level

```js
// shuvi.config.js

serverMiddleware: [
  { path: "*", handler: "api/cache", options: [{ maxAge: 2 * 60 * 1000 } }],
];
```

##### pros

- Easy to reuse under strict limit
