### PR TITLE
fix: make MultiStats available

### DIFF
--- a/packages/types/src/hooks.d.ts
+++ b/packages/types/src/hooks.d.ts
@@ -1,10 +1,14 @@
 import { defineHook } from '@shuvi/core';
-import webpack, { MultiStats } from 'webpack';
+import webpack, { MultiCompiler } from 'webpack';
+import { SyncHook } from 'tapable';
 import WebpackChain from 'webpack-chain';
 import WebpackDevMiddleware from 'webpack-dev-middleware';
 import { IApiConfig, IShuviMode } from '..';
 import { IUserRouteConfig, IDocumentProps } from './runtime';
 import { IWebpackHelpers } from './bundler';
+
+type ExtractSyncHookGeneric<Type> = Type extends SyncHook<infer X> ? X : never;
+export type MultiStats = ExtractSyncHookGeneric<MultiCompiler['hooks']['done']>[0];
 
 export type IHookGetConfig = defineHook<
   'getConfig',

--- a/packages/types/src/types/webpack.d.ts
+++ b/packages/types/src/types/webpack.d.ts
@@ -1,8 +1,0 @@
-import { MultiCompiler } from 'webpack';
-import { SyncHook } from 'tapable';
-
-type ExtractSyncHookGeneric<Type> = Type extends SyncHook<infer X> ? X : never;
-
-declare module 'webpack' {
-  type MultiStats = ExtractSyncHookGeneric<MultiCompiler['hooks']['done']>[0];
-}


### PR DESCRIPTION
declare the missing type instead of augmentation so that it is available for consumers
cc @ZhengYuTay 