### PR TITLE
fix(ChunkNamesPlugin): fix "Conflict: Multiple assets emit different content to the same filename"

### DIFF
--- a/packages/toolpack/src/webpack/plugins/chunk-names-plugin.ts
+++ b/packages/toolpack/src/webpack/plugins/chunk-names-plugin.ts
@@ -1,11 +1,11 @@
-import { Compiler } from 'webpack';
+import { Compiler, HotUpdateChunk } from 'webpack';
 
 // This plugin mirrors webpack 3 `filename` and `chunkfilename` behavior
 // This fixes https://github.com/webpack/webpack/issues/6598
 // This plugin is based on https://github.com/researchgate/webpack/commit/2f28947fa0c63ccbb18f39c0098bd791a2c37090
 export default class ChunkNamesPlugin {
   apply(compiler: Compiler) {
-    compiler.hooks.compilation.tap('ChunkNamesPlugin', (compilation: any) => {
+    compiler.hooks.compilation.tap('ChunkNamesPlugin', compilation => {
       compilation.hooks.renderManifest.intercept({
         register(tapInfo: any) {
           if (tapInfo.name === 'JavascriptModulesPlugin') {
@@ -15,9 +15,18 @@ export default class ChunkNamesPlugin {
               const chunk = options.chunk;
               const outputOptions = options.outputOptions;
 
+              // Note: fix Conflict: Multiple assets emit different content to the same filename static/chunks/page-xxxx.js
+              if (chunk instanceof HotUpdateChunk) {
+                return originalMethod(result, options);
+              }
+            
+              const chunkGraph = options.chunkGraph;
+              const hasEntryModule =
+                chunkGraph.getNumberOfEntryModules(chunk) > 0;
+
               if (chunk.filenameTemplate) {
                 filenameTemplate = chunk.filenameTemplate;
-              } else if (chunk.hasRuntime() || chunk.hasEntryModule()) {
+              } else if (chunk.hasRuntime() || hasEntryModule) {
                 filenameTemplate = outputOptions.filename;
               } else {
                 filenameTemplate = outputOptions.chunkFilename;


### PR DESCRIPTION
- fix Conflict: Multiple assets emit different content to the same filename
- [DEP_WEBPACK_CHUNK_HAS_ENTRY_MODULE] DeprecationWarning: Chunk.hasEntryModule: Use new ChunkGraph API
ref: https://github.com/webpack/webpack/blob/ec8e1bb0b3b8203818741f731fdf654e1583b2d4/lib/Chunk.js#L134

cc @ZhengYuTay 