### PR TITLE
feat: expose pluginApi.clientManifest

### DIFF
--- a/packages/shuvi/src/api/__tests__/api.test.ts
+++ b/packages/shuvi/src/api/__tests__/api.test.ts
@@ -4,6 +4,12 @@ import { IApiConfig, IPaths } from '@shuvi/types';
 import path from 'path';
 import { resolvePreset, resolvePlugin } from './utils';
 
+jest.mock('../initCoreResource', () => ({
+  initCoreResource: (api: any) => {
+    api.addResoure('clientManifest', () => ({ entries: [] }));
+  }
+}));
+
 describe('api', () => {
   test('should has "production" be default mode', async () => {
     const prodApi = await getApi({
@@ -16,7 +22,7 @@ describe('api', () => {
     test('should work', async () => {
       let pluginApi: PluginApi;
       const api = await getApi({
-        config: { plugins: [api => (pluginApi = api)] }
+        config: { plugins: [api => (pluginApi = api as PluginApi)] }
       });
       expect(pluginApi!).toBeDefined();
       expect(pluginApi!.paths).toBe(api.paths);
@@ -47,7 +53,10 @@ describe('api', () => {
         let pluginApi: PluginApi;
         const api = await getApi({
           config: {
-            plugins: [resolvePlugin('modify-config'), api => (pluginApi = api)]
+            plugins: [
+              resolvePlugin('modify-config'),
+              api => (pluginApi = api as PluginApi)
+            ]
           }
         });
         const plugins = (pluginApi! as any).__plugins;
@@ -85,13 +94,14 @@ describe('api', () => {
   test('getPluginApi', async () => {
     let pluginApi!: PluginApi;
     const api = await getApi({
-      config: { plugins: [api => (pluginApi = api)] }
+      config: { plugins: [api => (pluginApi = api as PluginApi)] }
     });
 
     expect(pluginApi.mode).toBe(api.mode);
     expect(pluginApi.paths).toBe(api.paths);
     expect(pluginApi.config).toBe(api.config);
     expect(pluginApi.phase).toBe(api.phase);
+    expect(pluginApi.clientManifest).toBe(api.resources.clientManifest);
 
     [
       'tap',

--- a/packages/shuvi/src/api/pluginApi.ts
+++ b/packages/shuvi/src/api/pluginApi.ts
@@ -30,6 +30,9 @@ class PluginApi implements IApi {
   config: any;
   phase: any;
 
+  // resources
+  clientManifest: any;
+
   // methods
   tap: any;
   callHook: any;
@@ -65,6 +68,10 @@ export function createPluginApi(api: Api): PluginApi {
       if (isApiProp(prop)) {
         const val = api[prop];
         return typeof val === 'function' ? val.bind(api) : val;
+      }
+
+      if (prop === 'clientManifest') {
+        return api.resources.clientManifest;
       }
 
       // @ts-ignore


### PR DESCRIPTION
Need to expose `api.clientManifest` from shuvi to get the bundles' filename like:

```js
// plugin
const sentryEntry = api.clientManifest.bundles[BUILD_CLIENT_RUNTIME_SENTRY_ENTRY]

documentProps.scriptTags.unshift({
  tagName: 'script',
  attrs: {
    src: api.getAssetPublicUrl(sentryEntry),
  },
})