### PR TITLE
feat(types): `getRoutes` now returns `IAppRouteConfig` without private properties

### DIFF
--- a/packages/app/core/routes.d.ts
+++ b/packages/app/core/routes.d.ts
@@ -1,5 +1,5 @@
 import { Runtime } from '@shuvi/service';
 
-declare const routes: Runtime.IAppRouteConfig[];
+declare const routes: Runtime.IAppRouteConfigWithPrivateProps[];
 
 export default routes;

--- a/packages/platform-mp/src/shuvi-app/index.ts
+++ b/packages/platform-mp/src/shuvi-app/index.ts
@@ -1,5 +1,3 @@
 import app from './App';
 import view from './view';
-const page404 = '404: Page not found';
-const getRoutes = (routes: any) => routes;
-export { view, app, page404, getRoutes };
+export { view, app };

--- a/packages/platform-web-react/src/shuvi-app/getRoutes.ts
+++ b/packages/platform-web-react/src/shuvi-app/getRoutes.ts
@@ -3,18 +3,23 @@ import { loadRouteComponent } from './loadRouteComponent';
 import { normalizeRoutes, INormalizeRoutesContext } from './utils/router';
 
 export default function getRoutes(
-  routes: Runtime.IAppRouteConfig[] | undefined,
+  routes: Runtime.IAppRouteConfigWithPrivateProps[],
   appContext: INormalizeRoutesContext = {}
 ): Runtime.IAppRouteConfig[] {
-  const getRoutesWithRequire = (routes: Runtime.IAppRouteConfig[]) =>
+  const getRoutesWithRequire = (
+    routes: Runtime.IAppRouteConfigWithPrivateProps[]
+  ): Runtime.IAppRouteConfig[] =>
     routes.map(x => {
-      const route = { ...x };
+      const originalRoute: Runtime.IAppRouteConfigWithPrivateProps = { ...x };
       const {
+        __componentSource__,
         __componentSourceWithAffix__,
         __import__,
         __resolveWeak__,
-        children
-      } = route;
+        children,
+        ...rest
+      } = originalRoute;
+      const route = { ...rest };
       if (children) {
         route.children = getRoutesWithRequire(children);
       }

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -57,6 +57,7 @@
     "http-proxy-middleware": "1.0.6",
     "launch-editor": "2.2.1",
     "raw-body": "^2.4.1",
+    "rimraf": "^3.0.2",
     "send": "0.17.1",
     "webpack": "5.36.0",
     "webpack-dev-middleware": "4.1.0"

--- a/packages/service/src/api/types.ts
+++ b/packages/service/src/api/types.ts
@@ -22,15 +22,27 @@ export interface IUserRouteConfig {
   id?: string;
 }
 
+export interface IAppRouteConfigWithPrivateProps extends IRouteRecord {
+  id: string;
+  component?: any;
+  children?: IAppRouteConfigWithPrivateProps[];
+  path: string;
+  __componentSource__: string;
+  __componentSourceWithAffix__: string;
+  __import__: () => Promise<any>;
+  __resolveWeak__: () => any;
+  [x: string]: any;
+}
+
 export interface IAppRouteConfig extends IRouteRecord {
   id: string;
   component?: any;
   children?: IAppRouteConfig[];
   path: string;
-  __componentSource__?: string;
-  __componentSourceWithAffix__?: string;
-  __import__?: () => Promise<any>;
-  __resolveWeak__?: () => any;
+  __componentSource__?: never;
+  __componentSourceWithAffix__?: never;
+  __import__?: never;
+  __resolveWeak__?: never;
   [x: string]: any;
 }
 export interface IApiRouteConfig {

--- a/packages/service/src/lib/routes.ts
+++ b/packages/service/src/lib/routes.ts
@@ -14,6 +14,9 @@ function genRouteId(filepath: string) {
   return createHash('md4').update(filepath).digest('hex').substr(0, 4);
 }
 
+/**
+ * returns JSON string of IAppRouteConfigWithPrivateProps
+ */
 export function serializeRoutes(
   routes: IUserRouteConfig[],
   parentPath: string = ''
@@ -32,7 +35,8 @@ export function serializeRoutes(
         const { component } = route;
         const componentSource = component;
         const componentSourceWithAffix = `${componentSource}?${ROUTE_RESOURCE_QUERYSTRING}`;
-        strRoute += `__componentSourceWithAffix__: "${componentSourceWithAffix}",
+        strRoute +=
+          `__componentSourceWithAffix__: "${componentSourceWithAffix}",
 __componentSource__: "${componentSource}",
 __import__: () => import(/* webpackChunkName: "page-${id}" */"${componentSourceWithAffix}"),
 __resolveWeak__: () => [require.resolveWeak("${componentSourceWithAffix}")]`.trim();

--- a/packages/service/src/types/runtime.ts
+++ b/packages/service/src/types/runtime.ts
@@ -4,6 +4,7 @@ import {
   IApi,
   IRouterHistoryMode,
   IAppRouteConfig,
+  IAppRouteConfigWithPrivateProps,
   IApiRouteConfig,
   IUserRouteConfig
 } from '../api';
@@ -36,11 +37,16 @@ export {
 export interface ITemplateData {
   [x: string]: any;
 }
-export { IUserRouteConfig, IAppRouteConfig, IApiRouteConfig };
+export {
+  IUserRouteConfig,
+  IAppRouteConfigWithPrivateProps,
+  IAppRouteConfig,
+  IApiRouteConfig
+};
 
 export interface IGetRoutes {
   (
-    routes: IAppRouteConfig[] | undefined,
+    routes: IAppRouteConfigWithPrivateProps[],
     context: IApplicationCreaterContext
   ): IAppRouteConfig[];
 }


### PR DESCRIPTION
To prevent routes private properties from being exposed at client