### PR TITLE
 :sparkles: feat(remove-api-children): 干掉无用的api children逻辑，增加函数返回类型

### DIFF
--- a/packages/platform-shared/src/node/route/route.ts
+++ b/packages/platform-shared/src/node/route/route.ts
@@ -38,6 +38,12 @@ export interface Routes {
   errors: RouteException[];
 }
 
+export interface RouteResult<T> {
+  warnings: RouteException[];
+  errors: RouteException[];
+  routes: T[];
+}
+
 export const getRawRoutesFromDir = async (dirname: string): Promise<Routes> => {
   if (!(await isDirectory(dirname))) {
     return {
@@ -109,7 +115,9 @@ export const getRawRoutesFromDir = async (dirname: string): Promise<Routes> => {
   };
 };
 
-export const getApiRoutes = async (dir: string) => {
+export const getApiRoutes = async (
+  dir: string
+): Promise<RouteResult<IRouteRecord>> => {
   const getConflictWaring = (
     rawRoute: RawRoute,
     conflictRawRoute: RawRoute
@@ -194,7 +202,9 @@ export const getApiRoutes = async (dir: string) => {
   };
 };
 
-export const getPageAndLayoutRoutes = async (dirname: string) => {
+export const getPageAndLayoutRoutes = async (
+  dirname: string
+): Promise<RouteResult<IRouteRecord>> => {
   const {
     routes: rawRoutes,
     warnings,
@@ -267,10 +277,11 @@ export const getPageAndLayoutRoutes = async (dirname: string) => {
 export type MiddlewareRecord = {
   middlewares: string[];
   path: string;
-  children?: MiddlewareRecord[];
 };
 
-export const getMiddlewareRoutes = async (dirname: string) => {
+export const getMiddlewareRoutes = async (
+  dirname: string
+): Promise<RouteResult<MiddlewareRecord>> => {
   const {
     routes: rawRoutes,
     warnings,

--- a/packages/platform-web/src/lib/features/api-middleware/lib/apiRoutes.ts
+++ b/packages/platform-web/src/lib/features/api-middleware/lib/apiRoutes.ts
@@ -2,7 +2,6 @@ import * as path from 'path';
 import { rankRouteBranches, IRouteRecord } from '@shuvi/router';
 export interface IApiRouteConfig {
   path: string;
-  children?: IApiRouteConfig[];
   apiModule: string;
 }
 
@@ -14,12 +13,9 @@ function flattenApiRoutes(
   parentPath = ''
 ): IApiRouteHandlerWithoutChildren[] {
   apiRoutes.forEach(route => {
-    const { children, apiModule } = route;
+    const { apiModule } = route;
     let tempPath = path.join(parentPath, route.path);
 
-    if (children) {
-      flattenApiRoutes(children, branches, tempPath);
-    }
     if (apiModule) {
       branches.push({
         path: tempPath,
@@ -61,7 +57,7 @@ export function renameFilepathToModule(
 ): IApiRouteConfig[] {
   const res: IApiRouteConfig[] = [];
   for (let index = 0; index < apiRoutes.length; index++) {
-    const { path, filepath, children } = apiRoutes[index];
+    const { path, filepath } = apiRoutes[index];
     const route = {
       path
     } as IApiRouteConfig;
@@ -70,9 +66,6 @@ export function renameFilepathToModule(
       route.apiModule = filepath;
     }
 
-    if (children && children.length > 0) {
-      route.children = renameFilepathToModule(children);
-    }
     res.push(route);
   }
   return res;
@@ -93,9 +86,6 @@ export function normalizeApiRoutes(
       apiRoute.apiModule = absPath.replace(/\\/g, '/');
     }
 
-    if (apiRoute.children && apiRoute.children.length > 0) {
-      apiRoute.children = normalizeApiRoutes(apiRoute.children, option);
-    }
     res.push(apiRoute);
   }
 


### PR DESCRIPTION
去掉了原有flatten api的逻辑，类型里也去掉了children，把三个主方法的返回值类型补上了。