### PR TITLE
fix/hmr-e2e

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ node_modules
 .idea/
 .swc
 .turbo
-
+packages/toolpack/src/swc/target
 
 # build output
 /lib/

--- a/test/e2e/hmr.test.ts
+++ b/test/e2e/hmr.test.ts
@@ -4,7 +4,7 @@ import {
   launchFixture,
   resolveFixture,
   check,
-  getIframeTextContent
+  checkShuviPortal
 } from '../utils';
 import { readFileSync, writeFileSync, renameSync, existsSync } from 'fs';
 
@@ -114,7 +114,6 @@ describe('Hot Module Reloading', () => {
       const pagePath = resolvePagePath('two');
       let originalContent: string | undefined;
       let done = false;
-
       try {
         page = await ctx.browser.page(ctx.url('/hmr/two'));
         expect(await page.$text('[data-test-id="hmr-two"]')).toBe(
@@ -122,6 +121,7 @@ describe('Hot Module Reloading', () => {
         );
 
         originalContent = readFileSync(pagePath, 'utf8');
+
         const editedContent = originalContent.replace(
           'This is the two page',
           '</div>'
@@ -132,8 +132,8 @@ describe('Hot Module Reloading', () => {
 
         // error box content
         await check(
-          () => getIframeTextContent(page),
-          t => /Error:/.test(t)
+          () => checkShuviPortal(page),
+          t => t
         );
 
         // add the original content

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -41,10 +41,6 @@ export async function check<T>(
   throw new Error('CHECK TIMED OUT: ' + lastErr);
 }
 
-export const getIframeTextContent = (page: Page) => {
-  return page.evaluate(() => {
-    return (
-      document.querySelector('iframe')?.contentDocument?.body.innerText || ''
-    );
-  });
+export const checkShuviPortal = (page: Page) => {
+  return page.evaluate(() => Boolean(document.querySelector('shuvi-portal')));
 };


### PR DESCRIPTION

**fix hmr e2e case**

具体的原因是因为原来是通过iframe寻找错误，现在换了新的overlay,已经不是iframe的形式了。