### PR TITLE
feat: add IHtmlDocument type at shuvi-runtime-server

### DIFF
--- a/packages/platform-web/src/node/shuvi-runtime-server.ts
+++ b/packages/platform-web/src/node/shuvi-runtime-server.ts
@@ -4,6 +4,7 @@ import {
 } from '@shuvi/service';
 import { IApiRequestHandler } from '../shared';
 import { extendedHooks } from './features/html-render/serverHooks';
+import type { IHtmlDocument } from './features/html-render/lib/renderer/types';
 
 declare global {
   namespace ShuviService {
@@ -40,6 +41,9 @@ export type HandlePageRequestFunction = RemoveLast<
 export type ModifyHtmlFunction = RemoveLast<
   ServerPluginConstructor['modifyHtml']
 >;
+
+/** indirect type of ModifyHtmlFunction */
+export type { IHtmlDocument };
 
 export type SendHtmlFunction = RemoveLast<ServerPluginConstructor['sendHtml']>;
 


### PR DESCRIPTION

User usually use this indirect type `IHtmlDocument` , but it is not exported from `ModifyHtmlFunction` together.

If not exported, use can only use `type IHtmlDocument = Parameters<ModifyHtmlFunction>[0]` instead.
