### PR TITLE
fix: close iframe directly

### DIFF
--- a/packages/error-overlay/src/client.ts
+++ b/packages/error-overlay/src/client.ts
@@ -112,6 +112,11 @@ function stopReportingRuntimeErrors() {
   window.removeEventListener('unhandledrejection', onUnhandledRejection);
 }
 
+function dismissRuntimeErrors() {
+  hasRuntimeError = false;
+  update();
+}
+
 function onBuildOk() {
   hasBuildError = false;
   errorTypeList.push({ type: TYPE_BUILD_OK });
@@ -180,7 +185,8 @@ function updateIframeContent() {
   const isRendered = iframe.contentWindow!.updateContent({
     errorTypeList,
     hasBuildError,
-    hasRuntimeError
+    hasRuntimeError,
+    dismissRuntimeErrors
   });
 
   //After the errors have been added to the queue of the error handler, we must clear the errorTypeList

--- a/packages/error-overlay/src/iframeScript.tsx
+++ b/packages/error-overlay/src/iframeScript.tsx
@@ -13,7 +13,12 @@ let iframeRoot = null;
 let errorBody = null;
 let isFirstRender = true;
 
-function render({ errorTypeList, hasBuildError, hasRuntimeError }) {
+function render({
+  errorTypeList,
+  hasBuildError,
+  hasRuntimeError,
+  dismissRuntimeErrors
+}) {
   errorTypeList.forEach((errorType: errorTypeHandler.ErrorTypeEvent) => {
     errorTypeHandler.emit(errorType);
   });
@@ -21,18 +26,20 @@ function render({ errorTypeList, hasBuildError, hasRuntimeError }) {
   if (!hasBuildError && !hasRuntimeError) {
     return null;
   }
-  return <ErrorOverlay />;
+  return <ErrorOverlay dismissRuntimeErrors={dismissRuntimeErrors} />;
 }
 
 window.updateContent = function updateContent({
   errorTypeList,
   hasBuildError,
-  hasRuntimeError
+  hasRuntimeError,
+  dismissRuntimeErrors
 }) {
   let renderedElement = render({
     errorTypeList,
     hasBuildError,
-    hasRuntimeError
+    hasRuntimeError,
+    dismissRuntimeErrors
   });
 
   if (renderedElement === null) {

--- a/packages/error-overlay/src/view/ErrorOverlay.tsx
+++ b/packages/error-overlay/src/view/ErrorOverlay.tsx
@@ -56,7 +56,13 @@ function reducer(
   }
 }
 
-export const ErrorOverlay = function ErrorOverlay() {
+export type ErrorOverlayProps = {
+  dismissRuntimeErrors: () => void;
+};
+
+export const ErrorOverlay: React.FC<ErrorOverlayProps> = function ErrorOverlay({
+  dismissRuntimeErrors
+}) {
   const [state, dispatch] = React.useReducer<
     React.Reducer<OverlayState, ErrorTypeHandler.ErrorTypeEvent>
   >(reducer, {
@@ -88,7 +94,7 @@ export const ErrorOverlay = function ErrorOverlay() {
           {hasBuildError ? (
             <BuildError error={state.buildError!} />
           ) : hasRuntimeErrors ? (
-            <RuntimeError errors={state.errors} />
+            <RuntimeError errors={state.errors} close={dismissRuntimeErrors} />
           ) : undefined}
         </ShadowPortal>
       ) : undefined}

--- a/packages/error-overlay/src/view/container/RuntimeError.tsx
+++ b/packages/error-overlay/src/view/container/RuntimeError.tsx
@@ -24,7 +24,10 @@ export type SupportedErrorEvent = {
   id: number;
   event: UnhandledError | UnhandledRejection;
 };
-export type RuntimeErrorProps = { errors: SupportedErrorEvent[] };
+export type RuntimeErrorProps = {
+  errors: SupportedErrorEvent[];
+  close: () => void;
+};
 
 type ReadyErrorEvent = ReadyRuntimeError;
 
@@ -43,7 +46,8 @@ function getErrorSignature(ev: SupportedErrorEvent): string {
 }
 
 export const RuntimeError: React.FC<RuntimeErrorProps> = function RuntimeError({
-  errors
+  errors,
+  close
 }) {
   const [lookups, setLookups] = React.useState(
     {} as { [eventId: string]: ReadyErrorEvent }
@@ -127,6 +131,7 @@ export const RuntimeError: React.FC<RuntimeErrorProps> = function RuntimeError({
   const minimize = React.useCallback((e?: MouseEvent | TouchEvent) => {
     e?.preventDefault();
     setDisplayState('minimized');
+    close();
   }, []);
   const hide = React.useCallback((e?: MouseEvent | TouchEvent) => {
     e?.preventDefault();


### PR DESCRIPTION
issue:
Because there is still an overlay layer after the element is minimized, so the user cannot interact with the page.

solution:
Refer to react-error-overlay practice, deleting the iframe when click close 'x' button.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests(unit,e2e) for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
