### PR TITLE
fix(router): allow empty route.path for correct catchAll ranking

### DIFF
--- a/examples/basic/.gitignore
+++ b/examples/basic/.gitignore
@@ -10,6 +10,7 @@
 
 # shuvi.js
 /.shuvi/
+build/
 
 # production
 /dist/

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -1,17 +1,18 @@
 {
   "private": true,
+  "name": "example-basic",
   "scripts": {
     "dev": "shuvi dev",
     "build": "shuvi build",
     "start": "shuvi start"
   },
   "dependencies": {
-    "shuvi": "1.0.0-rc.5"
+    "shuvi": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^18.6.1",
-    "@types/react": "^18.0.17",
-    "@types/react-dom": "^18.0.6",
+    "@types/react": "18.0.9",
+    "@types/react-dom": "18.0.6",
     "typescript": "^4.7.4"
   }
 }

--- a/examples/basic/src/routes/$/layout.tsx
+++ b/examples/basic/src/routes/$/layout.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { RouterView } from '@shuvi/runtime';
+
+export default function Layout() {
+  return (
+    <div
+      style={{
+        minHeight: '100vh'
+      }}
+    >
+      /$/layout.tsx
+      <RouterView />
+    </div>
+  );
+}
+
+export const loader = async () => {
+  console.log('[demo] /$/layout loader');
+  return {};
+};

--- a/examples/basic/src/routes/$/page.tsx
+++ b/examples/basic/src/routes/$/page.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export default function Home() {
+  return <>/$/pages.tsx</>;
+}
+export const loader = async () => {
+  console.log('[demo] /$/page loader');
+  return {};
+};

--- a/examples/basic/src/routes/$symbol/calc/layout.tsx
+++ b/examples/basic/src/routes/$symbol/calc/layout.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { RouterView } from '@shuvi/runtime';
+
+export default function Layout() {
+  return (
+    <div
+      style={{
+        minHeight: '100vh'
+      }}
+    >
+      /calc/layout.tsx
+      <RouterView />
+    </div>
+  );
+}
+
+export const loader = async () => {
+  console.log('[demo] /calc/layout loader');
+  return {};
+};

--- a/examples/basic/src/routes/$symbol/calc/page.tsx
+++ b/examples/basic/src/routes/$symbol/calc/page.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export default function Home() {
+  return <>/calc/pages.tsx</>;
+}
+export const loader = async () => {
+  console.log('[demo] /calc/page loader');
+  return {};
+};

--- a/examples/basic/src/routes/home/layout.tsx
+++ b/examples/basic/src/routes/home/layout.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { RouterView } from '@shuvi/runtime';
+
+export default function Layout() {
+  return (
+    <div
+      style={{
+        minHeight: '100vh'
+      }}
+    >
+      /home/layout.tsx
+      <RouterView />
+    </div>
+  );
+}
+
+export const loader = async () => {
+  console.log('[demo] /home/layout loader');
+  return {};
+};

--- a/examples/basic/src/routes/home/page.tsx
+++ b/examples/basic/src/routes/home/page.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export default function Home() {
+  return <>/home/pages.tsx</>;
+}
+export const loader = async () => {
+  console.log('[demo] /home/page loader');
+  return {};
+};

--- a/packages/router/src/__tests__/createRoutesFromArray.test.ts
+++ b/packages/router/src/__tests__/createRoutesFromArray.test.ts
@@ -47,4 +47,20 @@ describe('createRoutesFromArray', () => {
       { caseSensitive: false, path: '/' }
     ]);
   });
+
+  it('allow children with empty path', () => {
+    expect(
+      createRoutesFromArray([
+        { path: '/' },
+        { path: '/*', children: [{ path: '' }] }
+      ])
+    ).toStrictEqual([
+      { path: '/', caseSensitive: false },
+      {
+        path: '/*',
+        children: [{ path: '', caseSensitive: false }],
+        caseSensitive: false
+      }
+    ]);
+  });
 });

--- a/packages/router/src/__tests__/pathRanking.test.ts
+++ b/packages/router/src/__tests__/pathRanking.test.ts
@@ -24,18 +24,32 @@ describe('tokensToParser', () => {
 
   it('patch score for pageBranch which ends with empty route', () => {
     expect(
-      tokensToParser(tokenizePath('/home'), {}, { routes: [LeafPageRoute] }).score
+      tokensToParser(
+        tokenizePath('/home'),
+        {},
+        { routes: [{ path: '/home' }, LeafPageRoute] }
+      ).score
     ).toStrictEqual([[80], [80]]);
     expect(
-      tokensToParser(tokenizePath('/:symbol'), {}, { routes: [LeafPageRoute] })
-        .score
+      tokensToParser(
+        tokenizePath('/:symbol'),
+        {},
+        { routes: [{ path: '/:symbol' }, LeafPageRoute] }
+      ).score
     ).toStrictEqual([[60], [80]]);
     expect(
-      tokensToParser(tokenizePath('/:symbol/calc'), {}, { routes: [LeafPageRoute] })
-        .score
+      tokensToParser(
+        tokenizePath('/:symbol/calc'),
+        {},
+        { routes: [{ path: '/:symbol' }, { path: '/calc' }, LeafPageRoute] }
+      ).score
     ).toStrictEqual([[60], [80], [80]]);
     expect(
-      tokensToParser(tokenizePath('/*'), {}, { routes: [LeafPageRoute] }).score
+      tokensToParser(
+        tokenizePath('/*'),
+        {},
+        { routes: [{ path: '/*' }, LeafPageRoute] }
+      ).score
     ).toStrictEqual([[19], [80]]);
   });
 });

--- a/packages/router/src/__tests__/pathRanking.test.ts
+++ b/packages/router/src/__tests__/pathRanking.test.ts
@@ -29,28 +29,28 @@ describe('tokensToParser', () => {
         {},
         { routes: [{ path: '/home' }, LeafPageRoute] }
       ).score
-    ).toStrictEqual([[80], [80]]);
+    ).toStrictEqual([[80], [0.1]]);
     expect(
       tokensToParser(
         tokenizePath('/:symbol'),
         {},
         { routes: [{ path: '/:symbol' }, LeafPageRoute] }
       ).score
-    ).toStrictEqual([[60], [80]]);
+    ).toStrictEqual([[60], [0.1]]);
     expect(
       tokensToParser(
         tokenizePath('/:symbol/calc'),
         {},
         { routes: [{ path: '/:symbol' }, { path: '/calc' }, LeafPageRoute] }
       ).score
-    ).toStrictEqual([[60], [80], [80]]);
+    ).toStrictEqual([[60], [80], [0.1]]);
     expect(
       tokensToParser(
         tokenizePath('/*'),
         {},
         { routes: [{ path: '/*' }, LeafPageRoute] }
       ).score
-    ).toStrictEqual([[19], [80]]);
+    ).toStrictEqual([[19], [0.1]]);
   });
 });
 

--- a/packages/router/src/createRoutesFromArray.ts
+++ b/packages/router/src/createRoutesFromArray.ts
@@ -3,16 +3,24 @@ import { IPartialRouteRecord, IRouteRecord } from './types';
 export function createRoutesFromArray<
   T extends IPartialRouteRecord,
   U extends IRouteRecord
->(array: T[]): U[] {
+>(
+  array: T[],
+  /**
+   * allowEmptyPath: allow empty path for children
+   * A pageBranch could be ended with a page route with empty path.
+   */
+  allowEmptyPath = false
+): U[] {
   return array.map(partialRoute => {
+    const defaultPath = allowEmptyPath ? '' : '/';
     let route: U = {
       ...(partialRoute as any),
       caseSensitive: !!partialRoute.caseSensitive,
-      path: partialRoute.path || '/'
+      path: partialRoute.path || defaultPath
     };
 
     if (partialRoute.children) {
-      route.children = createRoutesFromArray(partialRoute.children);
+      route.children = createRoutesFromArray(partialRoute.children, true);
     }
 
     return route;

--- a/packages/router/src/matchRoutes.ts
+++ b/packages/router/src/matchRoutes.ts
@@ -62,9 +62,9 @@ export function rankRouteBranches<T extends [string, ...any[]]>(
   }
 
   const normalizedPaths = branches.map((branch, index) => {
-    const [path] = branch;
+    const [path, routes] = branch;
     return {
-      ...tokensToParser(tokenizePath(path)),
+      ...tokensToParser(tokenizePath(path), undefined, { routes }),
       path,
       index
     };
@@ -89,7 +89,15 @@ function flattenRoutes<T extends IRouteBaseObject>(
   parentIndexes: number[] = []
 ): IRouteBranch<T>[] {
   routes.forEach((route, index) => {
-    let path = joinPaths([parentPath, route.path]);
+    let path;
+    if (route.path === '') {
+      /**
+       * An empty path is allowed, don't append a slash.
+       */
+      path = parentPath;
+    } else {
+      path = joinPaths([parentPath, route.path]);
+    }
     let routes = parentRoutes.concat(route);
     let indexes = parentIndexes.concat(index);
 

--- a/packages/router/src/pathParserRanker.ts
+++ b/packages/router/src/pathParserRanker.ts
@@ -1,4 +1,4 @@
-import { Token, TokenType, TokenCatchAll, tokenizePath } from './pathTokenizer';
+import { Token, TokenType, TokenCatchAll } from './pathTokenizer';
 import { IRouteRecord } from './types';
 
 type PathParams = Record<string, string | string[]>;
@@ -114,7 +114,8 @@ const enum PathScore {
   BonusOptional = -0.8 * _multiplier, // /:w? or /:w*
   // these two have to be under 0.1 so a strict /:page is still lower than /:a-:b
   BonusStrict = 0.07 * _multiplier, // when options strict: true is passed, as the regex omits \/?
-  BonusCaseSensitive = 0.025 * _multiplier // when options strict: true is passed, as the regex omits \/?
+  BonusCaseSensitive = 0.025 * _multiplier, // when options strict: true is passed, as the regex omits \/?
+  BonusEmptyStringPath = 0.01 * _multiplier // when the path is an empty string
 }
 
 // Special Regex characters that must be escaped in static tokens
@@ -357,15 +358,14 @@ export function tokensToParser(
   }
 
   /**
-   * To make sure the score of pageBranch is always higher priority 
+   * To make sure the score of pageBranch is always higher priority
    * than the layoutRoute.
    * We append a bonus score if the last route is an empty path.
    */
   if (branchInfo?.routes) {
     const lastRoutePath = branchInfo.routes[branchInfo.routes.length - 1]?.path;
     if (lastRoutePath === '') {
-      const patchScore = tokensToParser(tokenizePath('/')).score;
-      score.push(...patchScore);
+      score.push([PathScore.BonusEmptyStringPath]);
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,25 @@ importers:
         specifier: 4.8.4
         version: 4.8.4
 
+  examples/basic:
+    dependencies:
+      shuvi:
+        specifier: workspace:*
+        version: link:../../packages/shuvi
+    devDependencies:
+      '@types/node':
+        specifier: ^18.6.1
+        version: 18.19.34
+      '@types/react':
+        specifier: 18.0.9
+        version: 18.0.9
+      '@types/react-dom':
+        specifier: 18.0.6
+        version: 18.0.6
+      typescript:
+        specifier: ^4.7.4
+        version: 4.8.4
+
   packages/compiler:
     dependencies:
       '@napi-rs/triples':
@@ -1002,6 +1021,12 @@ importers:
         version: link:../../../packages/shuvi
 
   test/fixtures/basic:
+    dependencies:
+      shuvi:
+        specifier: workspace:*
+        version: link:../../../packages/shuvi
+
+  test/fixtures/catch-all:
     dependencies:
       shuvi:
         specifier: workspace:*
@@ -5015,7 +5040,7 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.1
       '@types/keyv': 3.1.4
-      '@types/node': 18.0.6
+      '@types/node': 12.12.7
       '@types/responselike': 1.0.0
     dev: true
 
@@ -5093,7 +5118,7 @@ packages:
   /@types/fs-extra@9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
-      '@types/node': 18.0.6
+      '@types/node': 12.12.7
     dev: true
 
   /@types/glob@7.2.0:
@@ -5116,7 +5141,7 @@ packages:
   /@types/http-proxy@1.17.4:
     resolution: {integrity: sha512-IrSHl2u6AWXduUaDLqYpt45tLVCtYv7o4Z0s1KghBCDgIIS9oW5K1H8mZG/A2CfeLdEa7rTd1ACOiHBc1EMT2Q==}
     dependencies:
-      '@types/node': 18.0.6
+      '@types/node': 12.12.7
     dev: false
 
   /@types/istanbul-lib-coverage@2.0.1:
@@ -5185,7 +5210,7 @@ packages:
   /@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 18.0.6
+      '@types/node': 12.12.7
     dev: true
 
   /@types/loader-utils@2.0.1:
@@ -5229,7 +5254,6 @@ packages:
 
   /@types/node@12.12.7:
     resolution: {integrity: sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w==}
-    dev: true
 
   /@types/node@17.0.23:
     resolution: {integrity: sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==}
@@ -5237,6 +5261,13 @@ packages:
 
   /@types/node@18.0.6:
     resolution: {integrity: sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw==}
+    dev: true
+
+  /@types/node@18.19.34:
+    resolution: {integrity: sha512-eXF4pfBNV5DAMKGbI02NnDtWrQ40hAN558/2vvS4gMpMIxaf6JmD7YjnZbq0Q9TDSSkKBamime8ewRoomHdt4g==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: true
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -5313,7 +5344,7 @@ packages:
   /@types/responselike@1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 18.0.6
+      '@types/node': 12.12.7
     dev: true
 
   /@types/rimraf@3.0.0:
@@ -5327,7 +5358,7 @@ packages:
     resolution: {integrity: sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==}
     dependencies:
       '@types/glob': 7.2.0
-      '@types/node': 18.0.6
+      '@types/node': 12.12.7
     dev: true
 
   /@types/scheduler@0.16.2:
@@ -5337,14 +5368,14 @@ packages:
   /@types/semver@7.3.1:
     resolution: {integrity: sha512-ooD/FJ8EuwlDKOI6D9HWxgIgJjMg2cuziXm/42npDC8y4NjxplBUn9loewZiBNCt44450lHAU0OSb51/UqXeag==}
     dependencies:
-      '@types/node': 18.0.6
+      '@types/node': 12.12.7
     dev: true
 
   /@types/send@0.14.5:
     resolution: {integrity: sha512-0mwoiK3DXXBu0GIfo+jBv4Wo5s1AcsxdpdwNUtflKm99VEMvmBPJ+/NBNRZy2R5JEYfWL/u4nAHuTUTA3wFecQ==}
     dependencies:
       '@types/mime': 2.0.1
-      '@types/node': 18.0.6
+      '@types/node': 12.12.7
     dev: true
 
   /@types/source-list-map@0.1.2:
@@ -5410,7 +5441,7 @@ packages:
     resolution: {integrity: sha512-tWkdf9nO0zFgAY/EumUKwrDUhraHKDqCPhwfFR/R8l0qnPdgb9le0Gzhvb7uzVpouuDGBgiE//ZdY+5jcZy2TA==}
     dependencies:
       '@types/anymatch': 1.3.1
-      '@types/node': 18.0.6
+      '@types/node': 12.12.7
       '@types/tapable': 1.0.4
       '@types/uglify-js': 3.0.4
       '@types/webpack-sources': 0.1.5
@@ -11020,7 +11051,7 @@ packages:
       '@jest/fake-timers': 28.1.1
       '@jest/types': 28.1.1
       '@types/jsdom': 16.2.14
-      '@types/node': 18.0.6
+      '@types/node': 12.12.7
       jest-mock: 28.1.1
       jest-util: 28.1.1
       jsdom: 19.0.0
@@ -11296,7 +11327,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.0.6
+      '@types/node': 12.12.7
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: false
@@ -16293,6 +16324,10 @@ packages:
     dependencies:
       buffer: 5.6.0
       through: 2.3.8
+    dev: true
+
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: true
 
   /unicode-canonical-property-names-ecmascript@1.0.4:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,4 @@ packages:
   - 'test/fixtures/*'
   - 'test/packages/*'
   - 'test/utils'
+  - 'examples/*'

--- a/test/e2e/catch-all.test.ts
+++ b/test/e2e/catch-all.test.ts
@@ -1,0 +1,52 @@
+import { AppCtx, Page, devFixture } from '../utils';
+
+let ctx: AppCtx;
+let page: Page;
+
+jest.setTimeout(5 * 60 * 1000);
+
+describe('catch-all', () => {
+  beforeAll(async () => {
+    ctx = await devFixture('catch-all');
+  });
+  afterAll(async () => {
+    await ctx.close();
+  });
+  afterEach(async () => {
+    await page.close();
+  });
+
+  test('should exact match home page', async () => {
+    page = await ctx.browser.page(ctx.url('/home'));
+    await page.waitForSelector('[id="home-page"]');
+    expect(await page.$text('[id="global-layout"]')).toBe('/layout.js');
+    expect(await page.$text('[id="home-page"]')).toBe('/home/page.js');
+    expect(await page.$text('[id="home-layout"]')).toBe('/home/layout.js');
+  });
+
+  test('should match catchAll', async () => {
+    page = await ctx.browser.page(ctx.url('/other'));
+    await page.waitForSelector('[id="catchAll-page"]');
+    expect(await page.$text('[id="global-layout"]')).toBe('/layout.js');
+    expect(await page.$text('[id="catchAll-page"]')).toBe('/$/page.js');
+    expect(await page.$text('[id="catchAll-layout"]')).toBe('/$/layout.js');
+  });
+
+  test('should match /:symbol/calc', async () => {
+    page = await ctx.browser.page(ctx.url('/symbol/calc'));
+    await page.waitForSelector('[id="calc-page"]');
+    expect(await page.$text('[id="global-layout"]')).toBe('/layout.js');
+    expect(await page.$text('[id="calc-page"]')).toBe('/$symbol/calc/page.js');
+    expect(await page.$text('[id="calc-layout"]')).toBe(
+      '/$symbol/calc/layout.js'
+    );
+  });
+
+  test('/symbol/calc2 should match catchAll', async () => {
+    page = await ctx.browser.page(ctx.url('/symbol/calc2'));
+    await page.waitForSelector('[id="catchAll-page"]');
+    expect(await page.$text('[id="global-layout"]')).toBe('/layout.js');
+    expect(await page.$text('[id="catchAll-page"]')).toBe('/$/page.js');
+    expect(await page.$text('[id="catchAll-layout"]')).toBe('/$/layout.js');
+  });
+});

--- a/test/fixtures/catch-all/package.json
+++ b/test/fixtures/catch-all/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "fixture-catch-all",
+  "dependencies": {
+    "shuvi": "workspace:*"
+  }
+}

--- a/test/fixtures/catch-all/shuvi.config.js
+++ b/test/fixtures/catch-all/shuvi.config.js
@@ -1,0 +1,3 @@
+export default {
+  ssr: true
+};

--- a/test/fixtures/catch-all/src/routes/$/layout.js
+++ b/test/fixtures/catch-all/src/routes/$/layout.js
@@ -1,0 +1,10 @@
+import { RouterView } from '@shuvi/runtime';
+
+const Layout = () => (
+  <div>
+    <div id="catchAll-layout">/$/layout.js</div>
+    <RouterView />
+  </div>
+);
+
+export default Layout;

--- a/test/fixtures/catch-all/src/routes/$/page.js
+++ b/test/fixtures/catch-all/src/routes/$/page.js
@@ -1,0 +1,7 @@
+export default function Index() {
+  return (
+    <>
+      <div id="catchAll-page">/$/page.js</div>
+    </>
+  );
+}

--- a/test/fixtures/catch-all/src/routes/$symbol/calc/layout.js
+++ b/test/fixtures/catch-all/src/routes/$symbol/calc/layout.js
@@ -1,0 +1,10 @@
+import { RouterView } from '@shuvi/runtime';
+
+const Layout = () => (
+  <div>
+    <div id="calc-layout">/$symbol/calc/layout.js</div>
+    <RouterView />
+  </div>
+);
+
+export default Layout;

--- a/test/fixtures/catch-all/src/routes/$symbol/calc/page.js
+++ b/test/fixtures/catch-all/src/routes/$symbol/calc/page.js
@@ -1,0 +1,7 @@
+export default function Index() {
+  return (
+    <>
+      <div id="calc-page">/$symbol/calc/page.js</div>
+    </>
+  );
+}

--- a/test/fixtures/catch-all/src/routes/home/layout.js
+++ b/test/fixtures/catch-all/src/routes/home/layout.js
@@ -1,0 +1,10 @@
+import { RouterView } from '@shuvi/runtime';
+
+const Layout = () => (
+  <div>
+    <div id="home-layout">/home/layout.js</div>
+    <RouterView />
+  </div>
+);
+
+export default Layout;

--- a/test/fixtures/catch-all/src/routes/home/page.js
+++ b/test/fixtures/catch-all/src/routes/home/page.js
@@ -1,0 +1,7 @@
+export default function Index() {
+  return (
+    <>
+      <div id="home-page">/home/page.js</div>
+    </>
+  );
+}

--- a/test/fixtures/catch-all/src/routes/layout.js
+++ b/test/fixtures/catch-all/src/routes/layout.js
@@ -1,0 +1,10 @@
+import { RouterView } from '@shuvi/runtime';
+
+const GlobalLayout = () => (
+  <div>
+    <div id="global-layout">/layout.js</div>
+    <RouterView />
+  </div>
+);
+
+export default GlobalLayout;


### PR DESCRIPTION
Let's say you have a directory structure like this:

```
└── src
    └── routes
        ├── $
        │   ├── layout.js
        │   └── page.js
        ├── $symbol
	        ├── calc
	            ├── layout.js
	            └── page.js
        ├── home
        │   ├── layout.js
        │   └── page.js
        └── layout.js
```

## Current

❌ Visit localhost:3000/symbol/calc, the `src/routes/$/page` will be rendered.

## Expect 

✅ Visit localhost:3000/symbol/calc, the `src/routes/$symbol/calc/page` should be exactly matched and rendered.

## Root Cause

The rank of pathParser is not correct.