### PR TITLE
fix(toolpack): correct the filename of asset/resource

### DIFF
--- a/packages/toolpack/src/webpack/config/base.ts
+++ b/packages/toolpack/src/webpack/config/base.ts
@@ -238,7 +238,15 @@ export function baseWebpackChain({
     // @ts-ignore
     .type('asset/resource')
     .set('generator', {
-      filename: 'static/media/[name].[hash:8].[ext]'
+      filename: (pathData: { filename: string }) => {
+        // Check if a string is a base64 data URI
+        if (pathData.filename && isValidBase64DataURL(pathData.filename)) {
+          // Handle base64 string case, [name] is empty
+          return `static/media/base64.[hash:8][ext]`;
+        } else {
+          return `static/media/[name].[hash:8][ext]`;
+        }
+      }
     });
   // .use('file-loader')
   // .loader(require.resolve('file-loader'))
@@ -321,4 +329,31 @@ export function baseWebpackChain({
   }
 
   return config;
+}
+
+function isValidBase64DataURL(input: string): boolean {
+  // Check if input starts with the data URI scheme
+  if (!input.startsWith('data:')) {
+    return false;
+  }
+
+  // Split the data URI into metadata and data parts
+  const parts = input.split(',');
+  if (parts.length !== 2) {
+    return false;
+  }
+
+  const metadata = parts[0];
+  const data = parts[1];
+
+  // Check if the metadata contains 'base64'
+  if (!metadata.includes('base64')) {
+    return false;
+  }
+
+  // Regular expression to validate Base64 string
+  const base64Regex = /^[A-Za-z0-9+/]+[=]{0,2}$/;
+
+  // Validate Base64 data
+  return base64Regex.test(data);
 }

--- a/test/e2e/css.test.ts
+++ b/test/e2e/css.test.ts
@@ -78,9 +78,9 @@ jest.setTimeout(5 * 60 * 1000);
       // http://localhost:60874/static/media/btc.77643ddf.jpeg to be loaded
       const jpegStatus = imageStatuses.find(({ url }) =>
         /localhost:\d+\/static\/media\/btc\.[a-z0-9]+\.jpeg/.test(url)
-      );
-      expect(jpegStatus?.status).toBeTruthy();
-      expect(jpegStatus?.status).not.toEqual(404);
+      )?.status;
+      expect(jpegStatus).toBeTruthy();
+      expect(jpegStatus).not.toEqual(404);
 
       // no 404
       expect(imageStatuses.some(({ status }) => status === 404)).toBeFalsy();

--- a/test/e2e/css.test.ts
+++ b/test/e2e/css.test.ts
@@ -76,14 +76,14 @@ jest.setTimeout(5 * 60 * 1000);
       console.debug(`imageStatuses`, imageStatuses);
 
       // http://localhost:60874/static/media/btc.77643ddf.jpeg to be loaded
-      expect(
-        imageStatuses.find(({ url }) =>
-          /localhost:\d+\/static\/media\/btc\.[a-z0-9]+\.jpeg/.test(url)
-        )?.status
-      ).toEqual(200);
+      const jpegStatus = imageStatuses.find(({ url }) =>
+        /localhost:\d+\/static\/media\/btc\.[a-z0-9]+\.jpeg/.test(url)
+      );
+      expect(jpegStatus?.status).toBeTruthy();
+      expect(jpegStatus?.status).not.toEqual(404);
 
       // no 404
-      expect(imageStatuses.some(({ status }) => status !== 200)).toBeFalsy();
+      expect(imageStatuses.some(({ status }) => status === 404)).toBeFalsy();
     });
 
     test('should import .sass files', async () => {

--- a/test/e2e/css.test.ts
+++ b/test/e2e/css.test.ts
@@ -45,6 +45,47 @@ jest.setTimeout(5 * 60 * 1000);
       ).toBe('0.5');
     });
 
+    test('image should be loaded', async () => {
+      page = await ctx.browser.page();
+
+      const imageStatuses: {
+        url: string;
+        status: number;
+      }[] = [];
+
+      page.on('requestfinished', async request => {
+        const response = request.response();
+        const url = request.url();
+
+        if (!response) return;
+        const status = response.status();
+
+        if (request.resourceType() === 'image') {
+          imageStatuses.push({ url, status });
+        }
+      });
+      page.goto(ctx.url('/css'));
+      // wait for style inserting
+      await page.waitForTimeout(1000);
+      expect(
+        await page.$eval(
+          '#css',
+          (el: Element) => window.getComputedStyle(el).opacity
+        )
+      ).toBe('0.5');
+      console.debug(`imageStatuses`, imageStatuses);
+
+      // http://localhost:60874/static/media/btc.77643ddf.jpeg to be loaded
+      expect(
+        imageStatuses.find(({ url }) =>
+          /localhost:\d+\/static\/media\/btc\.[a-z0-9]+\.jpeg/.test(url)
+        )?.status
+      ).toEqual(200);
+
+      // no 404
+      expect(imageStatuses.some(({ status }) => status !== 200)).toBeFalsy();
+    });
+
     test('should import .sass files', async () => {
       page = await ctx.browser.page(ctx.url('/sass'));
       // wait for style inserting


### PR DESCRIPTION
## file-loader

<img width="409" alt="截圖 2024-06-12 10 40 39" src="https://github.com/shuvijs/shuvi/assets/1527371/3901f524-5702-46b8-a2fa-7a8f0daabf69">

#585 

## Before the PR

<img width="203" alt="before" src="https://github.com/shuvijs/shuvi/assets/1527371/1e9a5fe1-341f-4840-910a-4f3a36b56e4a">

1. ❌ duplicated double dot `..jpeg` ref: https://github.com/redwoodjs/redwood/pull/5477/files

2. ❌ 404 if `[name]` is empty ref; https://github.com/webpack/webpack/pull/15293/files#diff-b4740c50caab45039c96edb49d372058f37ffb563e9ce2e7a37ca0e9e0a4b2d6


## After the PR

<img width="266" alt="after" src="https://github.com/shuvijs/shuvi/assets/1527371/3dfa37c4-c478-47b3-a17c-6e2c82f58c51">
