### PR TITLE
feat: downgrade fatal crash error for `<Link>` component

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "shuvi dev",
     "build": "shuvi build && npm run lint",
-    "start": "shuvi start",
+    "start": "shuvi serve",
     "lint": "shuvi lint"
   },
   "dependencies": {

--- a/examples/basic/src/routes/fatal-link-demo/page.tsx
+++ b/examples/basic/src/routes/fatal-link-demo/page.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { Link } from '@shuvi/runtime';
+
+// @note test purpose to trigger runtime error
+const TO = undefined as unknown as string;
+
+export default function Page() {
+  return (
+    <div>
+      Demo runtime error - Link component missing required `prop.to`
+      <br />
+      <button id="button-link-without-to">
+        <Link to={TO}>Click to trigger a fatal error at runtime</Link>
+      </button>
+    </div>
+  );
+}

--- a/examples/basic/src/routes/home/layout.tsx
+++ b/examples/basic/src/routes/home/layout.tsx
@@ -16,7 +16,7 @@ export default function Layout() {
     >
       /home/layout.tsx
       <RouterView />
-      {/* @ts-ignore for test to is undefined */}
+      {/* @ts-expect-error for test "to" is undefined */}
       <Link>go /symbol/calc</Link>
     </div>
   );

--- a/examples/basic/src/routes/home/layout.tsx
+++ b/examples/basic/src/routes/home/layout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RouterView } from '@shuvi/runtime';
+import { RouterView, Link } from '@shuvi/runtime';
 
 export default function Layout() {
   React.useEffect(() => {
@@ -16,6 +16,8 @@ export default function Layout() {
     >
       /home/layout.tsx
       <RouterView />
+      {/* @ts-ignore for test to is undefined */}
+      <Link>go /symbol/calc</Link>
     </div>
   );
 }

--- a/examples/basic/src/routes/home/layout.tsx
+++ b/examples/basic/src/routes/home/layout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RouterView, Link } from '@shuvi/runtime';
+import { RouterView } from '@shuvi/runtime';
 
 export default function Layout() {
   React.useEffect(() => {
@@ -16,8 +16,6 @@ export default function Layout() {
     >
       /home/layout.tsx
       <RouterView />
-      {/* @ts-expect-error for test "to" is undefined */}
-      <Link>go /symbol/calc</Link>
     </div>
   );
 }

--- a/packages/router-react/src/Link.tsx
+++ b/packages/router-react/src/Link.tsx
@@ -83,8 +83,8 @@ const BaseLink = React.forwardRef<HTMLAnchorElement, LinkProps>(
  *
  * Production Mode: Downgrade fatal error
  *   1. console.error without causing an immediate page crash.
- *   2. Only after user clicks <Link>, trigger the error and page re-render.
- *   3. Display the "Internal Application Error" page.
+ *   2. Only after user clicks <Link>, page re-render
+ *      and display the "Internal Application Error" page.
  *
  * @issue https://github.com/shuvijs/shuvi/pull/596
  */

--- a/packages/router-react/src/Link.tsx
+++ b/packages/router-react/src/Link.tsx
@@ -76,15 +76,20 @@ const BaseLink = React.forwardRef<HTMLAnchorElement, LinkProps>(
 );
 
 /**
- * @NOTE A Link wrapper to improve runtime error UX if `to` is not defined.
+ * @NOTE Improve Page Stability by Handling Fatal Crashes 致命錯誤降級處理
  *
- * At dev mode: Page crash directly
- *   -> show "Internal Application Error" page.
+ * Development Mode:
+ *   On fatal errors, immediately show the "Internal Application Error" page.
  *
- * At prod mode: Downgrade fatal error
- *   1. console.error first without page crash
- *   2. throw error after click
- *   3. re-render -> show "Internal Application Error" page
+ * Production Mode:: Downgrade fatal error
+ *   1. Log the error with console.error
+ *      without causing an immediate page crash.
+ *   2. Trigger the error and page re-render
+ *      only after user interaction (e.g., button click).
+ *   3. Re-render to display the "Internal Application Error" page
+ *      after the fatal error is thrown.
+ *
+ * @issue https://github.com/shuvijs/shuvi/pull/596
  */
 export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
   function LinkWithRef(props, ref) {

--- a/packages/router-react/src/Link.tsx
+++ b/packages/router-react/src/Link.tsx
@@ -81,13 +81,10 @@ const BaseLink = React.forwardRef<HTMLAnchorElement, LinkProps>(
  * Development Mode:
  *   On fatal errors, immediately show the "Internal Application Error" page.
  *
- * Production Mode:: Downgrade fatal error
- *   1. Log the error with console.error
- *      without causing an immediate page crash.
- *   2. Trigger the error and page re-render
- *      only after user interaction (e.g., button click).
- *   3. Re-render to display the "Internal Application Error" page
- *      after the fatal error is thrown.
+ * Production Mode: Downgrade fatal error
+ *   1. console.error without causing an immediate page crash.
+ *   2. Only after user clicks <Link>, trigger the error and page re-render.
+ *   3. Display the "Internal Application Error" page.
  *
  * @issue https://github.com/shuvijs/shuvi/pull/596
  */

--- a/test/e2e/link-without-to-props.test.ts
+++ b/test/e2e/link-without-to-props.test.ts
@@ -18,7 +18,6 @@ describe('link prop.to - [dev mode]', () => {
 
   test(`immediately show the "Internal Application Error" page`, async () => {
     page = await ctx.browser.page(ctx.url('/fatal-link-demo'));
-    await page.waitForTimeout(1000);
     expect(await page.$text('#__APP')).toContain(
       `500` // 500 error
     );
@@ -39,25 +38,16 @@ describe('link prop.to - [prod mode]', () => {
     await page.close();
   });
 
-  test(`Log the error with console.error`, async () => {
+  test(`downgrade fatal crashes`, async () => {
     page = await ctx.browser.page(ctx.url('/fatal-link-demo'));
-    const log = page.collectBrowserLog();
-    await page.waitForSelector('#button-link-without-to');
-    expect(await page.$text('#button-link-without-to')).toEqual(
+
+    // 1. without causing an immediate page crash.
+    expect(await page.$text('#button-link-without-to')).toContain(
       'Click to trigger a fatal error at runtime'
     );
-    console.debug(`[logs]`, log.texts);
-    expect(log.texts).toContain(
-      `The prop 'to' is required in '<Link>', but its value is 'undefined'`
-    );
-    log.dispose();
-  });
 
-  test(`display the "Internal Application Error" page after click`, async () => {
-    page = await ctx.browser.page(ctx.url('/fatal-link-demo'));
-    await page.waitForSelector('#button-link-without-to');
+    // 2. Only after user clicks <Link>, page re-render and display the "Internal Application Error" page.
     await page.click('#button-link-without-to');
-    await page.waitForTimeout(1000);
     expect(await page.$text('#__APP')).toContain('Internal Application Error');
   });
 });

--- a/test/e2e/link-without-to-props.test.ts
+++ b/test/e2e/link-without-to-props.test.ts
@@ -1,0 +1,57 @@
+import { AppCtx, Page, devFixture, serveFixture } from '../utils';
+
+let ctx: AppCtx;
+let page: Page;
+
+jest.setTimeout(5 * 60 * 1000);
+
+describe('link prop.to - dev mode', () => {
+  beforeAll(async () => {
+    ctx = await devFixture('basic', { ssr: true });
+  });
+  afterAll(async () => {
+    await ctx.close();
+  });
+  afterEach(async () => {
+    await page.close();
+  });
+
+  test(`immediately show the "Internal Application Error" page`, async () => {
+    page = await ctx.browser.page(ctx.url('/fatal-link-demo'));
+    await page.waitForTimeout(1000);
+    expect(await page.$text('#__APP')).toContain('Internal Application Error');
+  });
+});
+
+describe('link prop.to - prod mode', () => {
+  beforeAll(async () => {
+    ctx = await serveFixture('basic', { ssr: true });
+  });
+  afterAll(async () => {
+    await ctx.close();
+  });
+  afterEach(async () => {
+    await page.close();
+  });
+
+  test(`Log the error with console.error`, async () => {
+    page = await ctx.browser.page(ctx.url('/fatal-link-demo'));
+    const log = page.collectBrowserLog();
+    await page.waitForSelector('#button-link-without-to');
+    expect(await page.$text('#button-link-without-to')).toEqual(
+      'Click to trigger a fatal error at runtime'
+    );
+    expect(log.texts).toContain(
+      `The prop 'to' is required in '<Link>', but its value is 'undefined'`
+    );
+    log.dispose();
+  });
+
+  test(`display the "Internal Application Error" page after click`, async () => {
+    page = await ctx.browser.page(ctx.url('/fatal-link-demo'));
+    await page.waitForSelector('#button-link-without-to');
+    await page.click('#button-link-without-to');
+    await page.waitForTimeout(1000);
+    expect(await page.$text('#__APP')).toContain('Internal Application Error');
+  });
+});

--- a/test/e2e/link-without-to-props.test.ts
+++ b/test/e2e/link-without-to-props.test.ts
@@ -5,7 +5,7 @@ let page: Page;
 
 jest.setTimeout(5 * 60 * 1000);
 
-describe('link prop.to - dev mode', () => {
+describe('link prop.to - [dev mode]', () => {
   beforeAll(async () => {
     ctx = await devFixture('basic', { ssr: true });
   });
@@ -19,11 +19,16 @@ describe('link prop.to - dev mode', () => {
   test(`immediately show the "Internal Application Error" page`, async () => {
     page = await ctx.browser.page(ctx.url('/fatal-link-demo'));
     await page.waitForTimeout(1000);
-    expect(await page.$text('#__APP')).toContain('Internal Application Error');
+    expect(await page.$text('#__APP')).toContain(
+      `500` // 500 error
+    );
+    expect(await page.$text('#__APP')).toContain(
+      `Cannot read properties of undefined (reading 'pathname')`
+    );
   });
 });
 
-describe('link prop.to - prod mode', () => {
+describe('link prop.to - [prod mode]', () => {
   beforeAll(async () => {
     ctx = await serveFixture('basic', { ssr: true });
   });
@@ -41,6 +46,7 @@ describe('link prop.to - prod mode', () => {
     expect(await page.$text('#button-link-without-to')).toEqual(
       'Click to trigger a fatal error at runtime'
     );
+    console.debug(`[logs]`, log.texts);
     expect(log.texts).toContain(
       `The prop 'to' is required in '<Link>', but its value is 'undefined'`
     );

--- a/test/fixtures/basic/src/routes/fatal-link-demo/page.js
+++ b/test/fixtures/basic/src/routes/fatal-link-demo/page.js
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { Link } from '@shuvi/runtime';
+
+// @note test purpose to trigger runtime error
+const TO = undefined;
+
+export default function Page() {
+  return (
+    <div>
+      Demo runtime error - Link component missing required `prop.to`
+      <br />
+      <button id="button-link-without-to">
+        <Link to={TO}>Click to trigger a fatal error at runtime</Link>
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
# Improve Page Stability by Handling Fatal Crashes 致命錯誤降級處理

## Development Mode:

On fatal errors, immediately show the "Internal Application Error" page.

 
 ## Production Mode: Downgrade fatal error


1. console.error without causing an immediate page crash.
2. Only after user clicks `<Link>`, page re-render and display the "Internal Application Error" page.

 
![Large GIF (1034x742)](https://github.com/user-attachments/assets/59f7a009-314a-45c1-a1de-668f28ec1237)
