### PR TITLE
fix: ignorable errors should not affect react refresh

### DIFF
--- a/packages/error-overlay/src/client.ts
+++ b/packages/error-overlay/src/client.ts
@@ -73,7 +73,7 @@ function onUnhandledRejection(ev: PromiseRejectionEvent) {
   update();
 }
 
-function startReportingRuntimeErrors({ onError }: { onError: () => void }) {
+function startReportingRuntimeErrors({ onError }: { onError: (ev: ErrorEvent | PromiseRejectionEvent) => void }) {
   if (isRegistered) {
     return;
   }
@@ -86,11 +86,11 @@ function startReportingRuntimeErrors({ onError }: { onError: () => void }) {
   } catch {}
 
   window.addEventListener('error', ev => {
-    onError();
+    onError(ev);
     onUnhandledError(ev);
   });
   window.addEventListener('unhandledrejection', ev => {
-    onError();
+    onError(ev);
     onUnhandledRejection(ev);
   });
 }

--- a/packages/platform-web/src/shuvi-app/dev/hotDevClient.ts
+++ b/packages/platform-web/src/shuvi-app/dev/hotDevClient.ts
@@ -65,7 +65,12 @@ export default function connect(options: {
   assetPublicPath: string;
 }): HotDevClient {
   startReportingRuntimeErrors({
-    onError: function () {
+    onError: function (ev: ErrorEvent | PromiseRejectionEvent) {
+      const errorOrReason = ev?.error || ev?.reason;
+      if (!errorOrReason || !(errorOrReason instanceof Error) || typeof errorOrReason.stack !== 'string') {
+        // A non-error was thrown, we don't have anything to show.
+        return;
+      }
       hadRuntimeError = true;
     }
   });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
perf: 一些无关紧要的错误应该被忽略，比如 [error-overlay](https://github.com/shuvijs/shuvi/blob/main/packages/error-overlay/src/client.ts#L42) 这里对没有错误堆栈的 error 有 if 条件判断拦截，故不会通过弹窗的形式透出给用户。
而热更新 [hotDevClient](https://github.com/shuvijs/shuvi/blob/main/packages/platform-web/src/shuvi-app/dev/hotDevClient.ts#L69) 这里没有上面的 if 条件判断拦截，导致用户感知不到错误发生的情况下页面直接 [location.reload](https://github.com/shuvijs/shuvi/blob/main/packages/platform-web/src/shuvi-app/dev/hotDevClient.ts#L340C14-L340C31) 而不是 ReactRefresh 热更新

**Did you add tests(unit,e2e) for your changes?**
no

**Does this PR introduce a breaking change?**
no

**What needs to be documented once your changes are merged?**
no
