### PR TITLE
feat: dev mode support Chrome Extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           version: ^8.9.2
 
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'

--- a/.github/workflows/release-swc.yml
+++ b/.github/workflows/release-swc.yml
@@ -218,7 +218,7 @@ jobs:
             turbo-${{ github.job }}-canary-${{ matrix.settings.target }}-${{ needs.build.outputs.weekNum }}-
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         if: ${{ !matrix.settings.docker }}
         with:
           node-version: 16

--- a/packages/error-overlay/src/client.ts
+++ b/packages/error-overlay/src/client.ts
@@ -145,8 +145,10 @@ function applyStyles(element: HTMLElement, styles: Object) {
 }
 
 function update() {
-  // chrome-extension does not support inline scripts
-  if (window.location.protocol === 'chrome-extension:') {
+  // extensions does not support inline scripts, error overlay will be blank and block interaction in extensions
+  // so we need to remove it
+  // protocols list of extensions: moz-extension|chrome-extension|extension|safari-extension|safari-web-extension
+  if (window.location.protocol.endsWith('extension:')) {
     return;
   }
   // Loading iframe can be either sync or async depending on the browser.

--- a/packages/error-overlay/src/client.ts
+++ b/packages/error-overlay/src/client.ts
@@ -145,6 +145,10 @@ function applyStyles(element: HTMLElement, styles: Object) {
 }
 
 function update() {
+  // chrome-extension does not support inline scripts
+  if (window.location.protocol === 'chrome-extension:') {
+    return;
+  }
   // Loading iframe can be either sync or async depending on the browser.
   if (isLoadingIframe) {
     // Iframe is loading.

--- a/packages/platform-shared/src/shared/helper/getAppData.ts
+++ b/packages/platform-shared/src/shared/helper/getAppData.ts
@@ -15,6 +15,8 @@ export type IAppData<Data = {}, appState = any> = {
   };
   filesByRoutId: Record<string, string[]>;
   publicPath: string;
+  // devServer is only available in dev mode
+  devServer?: string;
 } & {
   [K in keyof Data]: Data[K];
 };

--- a/packages/platform-web/src/node/features/html-render/lib/renderer/base.ts
+++ b/packages/platform-web/src/node/features/html-render/lib/renderer/base.ts
@@ -123,7 +123,9 @@ export abstract class BaseRenderer {
     const data = JSON.stringify({
       ...appData,
       filesByRoutId: generateFilesByRoutId(resources.clientManifest, routes),
-      publicPath: this._serverPluginContext.assetPublicPath
+      publicPath: this._serverPluginContext.assetPublicPath,
+      // process.env.DEV_SERVER is undefined in production, and the key devServer will be removed
+      devServer: process.env.DEV_SERVER
     });
     return tag(
       'script',

--- a/packages/platform-web/src/node/features/html-render/lib/renderer/index.ts
+++ b/packages/platform-web/src/node/features/html-render/lib/renderer/index.ts
@@ -50,6 +50,10 @@ function addEssentialTagsIfMissing(document: IHtmlDocument): IHtmlDocument {
     );
   }
 
+  if (process.env.DEV_SERVER) {
+    document.htmlAttrs['dev-server'] = process.env.DEV_SERVER;
+  }
+
   return document;
 }
 

--- a/packages/platform-web/src/node/features/html-render/lib/renderer/index.ts
+++ b/packages/platform-web/src/node/features/html-render/lib/renderer/index.ts
@@ -50,10 +50,6 @@ function addEssentialTagsIfMissing(document: IHtmlDocument): IHtmlDocument {
     );
   }
 
-  if (process.env.DEV_SERVER) {
-    document.htmlAttrs['dev-server'] = process.env.DEV_SERVER;
-  }
-
   return document;
 }
 

--- a/packages/platform-web/src/shuvi-app/dev/websocket.ts
+++ b/packages/platform-web/src/shuvi-app/dev/websocket.ts
@@ -1,3 +1,5 @@
+import { getAppData } from '@shuvi/platform-shared/shared';
+
 let source: any;
 const eventCallbacks: ((event: any) => void)[] = [];
 let lastActivity = Date.now();
@@ -10,7 +12,7 @@ function getSocketProtocol(assetPublicPath: string): string {
     // assetPublicPath is a url
     protocol = new URL(assetPublicPath).protocol;
   } catch (_) {}
-
+  // use ws by default
   return protocol === 'https:' ? 'wss' : 'ws';
 }
 
@@ -51,8 +53,10 @@ export function connectHMR(options: {
 
   function init() {
     if (source) source.close();
-    let devServer = document?.documentElement?.getAttribute?.('dev-server');
+
+    let { devServer } = getAppData();
     if (!devServer) {
+      // fallback case
       const { hostname, port } = window.location;
       devServer = `${hostname}:${port}`;
     }

--- a/packages/platform-web/src/shuvi-app/dev/websocket.ts
+++ b/packages/platform-web/src/shuvi-app/dev/websocket.ts
@@ -11,7 +11,7 @@ function getSocketProtocol(assetPublicPath: string): string {
     protocol = new URL(assetPublicPath).protocol;
   } catch (_) {}
 
-  return protocol === 'http:' ? 'ws' : 'wss';
+  return protocol === 'https:' ? 'wss' : 'ws';
 }
 
 export function addMessageListener(cb: (event: any) => void) {
@@ -51,14 +51,17 @@ export function connectHMR(options: {
 
   function init() {
     if (source) source.close();
-
-    const { hostname, port } = window.location;
+    let devServer = document?.documentElement?.getAttribute?.('dev-server');
+    if (!devServer) {
+      const { hostname, port } = window.location;
+      devServer = `${hostname}:${port}`;
+    }
     const protocol = getSocketProtocol(options.assetPublicPath);
     const assetPublicPath = options.assetPublicPath
       .replace(/^\/+/, '')
       .replace(/\/+$/, '');
 
-    let url = `${protocol}://${hostname}:${port}${
+    let url = `${protocol}://${devServer}${
       assetPublicPath ? `/${assetPublicPath}` : ''
     }`;
 

--- a/packages/shuvi/src/commands/dev.ts
+++ b/packages/shuvi/src/commands/dev.ts
@@ -39,7 +39,7 @@ async function devAction(dir: string, options: DevOptions) {
   const { host, port } = options;
   const configFile = options.config && path.resolve(cwd, options.config);
   const config = await getConfigFromCli(options);
-  
+
   process.env.DEV_SERVER = `${host}:${port}`;
   const api = await initShuvi({
     cwd,

--- a/packages/shuvi/src/commands/dev.ts
+++ b/packages/shuvi/src/commands/dev.ts
@@ -39,7 +39,8 @@ async function devAction(dir: string, options: DevOptions) {
   const { host, port } = options;
   const configFile = options.config && path.resolve(cwd, options.config);
   const config = await getConfigFromCli(options);
-
+  
+  process.env.DEV_SERVER = `${host}:${port}`;
   const api = await initShuvi({
     cwd,
     config,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Without changing the original behavior of the web, add dev mode (HMR) support for Chrome Extension. 
For example, the URL of the Chrome Extension is `chrome-extension://aadcagccgjahnobpkadnbllfoajnoemi/index.html`, and the HMR websocket link (`ws://localhost:3000`) cannot be obtained through `window.location`. 
This PR will put `dev_server` info in`__APP_DATA` for the client to get.
